### PR TITLE
Clojure 1.9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject unicode-math "0.2.0"
+(defproject unicode-math "0.2.1"
   :description "A Clojure library designed to let you painfully write easily readable math."
   :url "https://github.com/Adereth/unicode-math"
   :license {:name "Eclipse Public License"

--- a/src/unicode_math/core.clj
+++ b/src/unicode_math/core.clj
@@ -1,5 +1,5 @@
 (ns unicode-math.core
-  (require [clojure.set :as set]))
+  (:require [clojure.set :as set]))
 
 (def ½ 1/2)
 (def ¼ 1/4)


### PR DESCRIPTION
Hi Matt. Big fan here; you got me to learn Clojure. Love the APL feel of this project. I want to keep using it in my fork of the Dactyl, but I’ve transitioned to Clojure 1.9 to get `clojure.spec` in that fork so I can take user input via sanity-checked YAML instead of having the configuration be part of the program.

`clojure.spec` does not approve of the `require` symbol in your `ns`. It seems to want a keyword.

Some context on the general problem can be found [here](https://groups.google.com/forum/#!topic/clojure/mIlKaOiujlo).

The compilation failure I get (in the local version of my Dactyl fork) is this:

```$ lein run
Compiling dactyl-keyboard.core
WARNING: boolean? already refers to: #'clojure.core/boolean? in namespace: clojure.tools.analyzer.utils, being replaced by: #'clojure.tools.analyzer.utils/boolean?
WARNING: boolean? already refers to: #'clojure.core/boolean? in namespace: clojure.tools.analyzer, being replaced by: #'clojure.tools.analyzer.utils/boolean?
clojure.lang.ExceptionInfo: Call to clojure.core/ns did not conform to spec:
In: [1] val: ((require [clojure.set :as set])) fails spec: :clojure.core.specs.alpha/ns-form at: [:args] predicate: (cat :docstring (? string?) :attr-map (? map?) :clauses :clojure.core.specs.alpha/ns-clauses),  Extra input
 #:clojure.spec.alpha{:problems [{:path [:args], :reason "Extra input", :pred (clojure.spec.alpha/cat :docstring (clojure.spec.alpha/? clojure.core/string?) :attr-map (clojure.spec.alpha/? clojure.core/map?) :clauses :clojure.core.specs.alpha/ns-clauses), :val ((require [clojure.set :as set])), :via [:clojure.core.specs.alpha/ns-form], :in [1]}], :spec #object[clojure.spec.alpha$regex_spec_impl$reify__2436 0x4cee7fa0 "clojure.spec.alpha$regex_spec_impl$reify__2436@4cee7fa0"], :value (unicode-math.core (require [clojure.set :as set])), :args (unicode-math.core (require [clojure.set :as set]))}, compiling:(unicode_math/core.clj:1:1)
Exception in thread "main" clojure.lang.ExceptionInfo: Call to clojure.core/ns did not conform to spec:
In: [1] val: ((require [clojure.set :as set])) fails spec: :clojure.core.specs.alpha/ns-form at: [:args] predicate: (cat :docstring (? string?) :attr-map (? map?) :clauses :clojure.core.specs.alpha/ns-clauses),  Extra input
 #:clojure.spec.alpha{:problems [{:path [:args], :reason "Extra input", :pred (clojure.spec.alpha/cat :docstring (clojure.spec.alpha/? clojure.core/string?) :attr-map (clojure.spec.alpha/? clojure.core/map?) :clauses :clojure.core.specs.alpha/ns-clauses), :val ((require [clojure.set :as set])), :via [:clojure.core.specs.alpha/ns-form], :in [1]}], :spec #object[clojure.spec.alpha$regex_spec_impl$reify__2436 0x4cee7fa0 "clojure.spec.alpha$regex_spec_impl$reify__2436@4cee7fa0"], :value (unicode-math.core (require [clojure.set :as set])), :args (unicode-math.core (require [clojure.set :as set]))}, compiling:(unicode_math/core.clj:1:1)
	at clojure.lang.Compiler.checkSpecs(Compiler.java:6891)
```
... and so on with a stack trace. I believe the operative part there is `:clojure.spec.alpha/value (unicode-math.core (require [clojure.set :as set]))`.

Please consider this proposed fix.